### PR TITLE
Consertada decisões quando app já está utilizando recurso ao máx/min

### DIFF
--- a/asgard/workers/autoscaler/simple_decision_component.py
+++ b/asgard/workers/autoscaler/simple_decision_component.py
@@ -24,7 +24,7 @@ class DecisionComponent(DecisionComponentInterface):
             if app.app_stats:
                 decision = Decision(app.id)
 
-                if app.is_set_to_scale_cpu() and app.cpu_needs_scaling():
+                if app.cpu_needs_scaling():
                     new_cpu = (
                         app.get_cpu_usage() * app.cpu_allocated
                     ) / app.cpu_threshold
@@ -63,7 +63,7 @@ class DecisionComponent(DecisionComponentInterface):
                         }
                     )
 
-                if app.is_set_to_scale_mem() and app.mem_needs_scaling():
+                if app.mem_needs_scaling():
                     new_mem = (
                         app.get_mem_usage() * app.mem_allocated
                     ) / app.mem_threshold

--- a/asgard/workers/converters/asgard_converter.py
+++ b/asgard/workers/converters/asgard_converter.py
@@ -77,8 +77,8 @@ class AppStatsConverter(Converter[AppStats, AppStatsDto]):
             return None
 
         app_stats = AppStats()
-        app_stats.cpu_usage = float(dto_object.stats.cpu_pct)
-        app_stats.mem_usage = float(dto_object.stats.ram_pct)
+        app_stats.cpu_usage = float(dto_object.stats.cpu_pct) / 100
+        app_stats.mem_usage = float(dto_object.stats.ram_pct) / 100
 
         return app_stats
 

--- a/asgard/workers/models/app_stats.py
+++ b/asgard/workers/models/app_stats.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
+
 class AppStats:
-    def __init__(self, cpu_usage: float = None, mem_usage: float = None):
+    def __init__(self, cpu_usage: Optional[float] = None, mem_usage: Optional[float] = None):
         self.cpu_usage = cpu_usage
         self.mem_usage = mem_usage

--- a/asgard/workers/models/app_stats.py
+++ b/asgard/workers/models/app_stats.py
@@ -2,6 +2,10 @@ from typing import Optional
 
 
 class AppStats:
-    def __init__(self, cpu_usage: Optional[float] = None, mem_usage: Optional[float] = None):
+    def __init__(
+        self,
+        cpu_usage: Optional[float] = None,
+        mem_usage: Optional[float] = None,
+    ):
         self.cpu_usage = cpu_usage
         self.mem_usage = mem_usage

--- a/asgard/workers/models/scalable_app.py
+++ b/asgard/workers/models/scalable_app.py
@@ -45,13 +45,13 @@ class ScalableApp:
         return self.app_stats.mem_usage
 
     def cpu_needs_scaling(self) -> bool:
-        return (
+        return self.is_set_to_scale_cpu() and (
             abs(self.get_cpu_usage() - self.cpu_threshold)
             > settings.AUTOSCALER_MARGIN_THRESHOLD
         )
 
     def mem_needs_scaling(self) -> bool:
-        return (
+        return self.is_set_to_scale_mem() and (
             abs(self.get_mem_usage() - self.mem_threshold)
             > settings.AUTOSCALER_MARGIN_THRESHOLD
         )

--- a/asgard/workers/models/scalable_app.py
+++ b/asgard/workers/models/scalable_app.py
@@ -35,3 +35,21 @@ class ScalableApp:
 
     def is_set_to_scale(self) -> bool:
         return self.is_set_to_scale_cpu() or self.is_set_to_scale_mem()
+
+    def get_cpu_usage(self) -> float:
+        return self.app_stats.cpu_usage
+
+    def get_mem_usage(self) -> float:
+        return self.app_stats.mem_usage
+
+    def cpu_needs_scaling(self) -> bool:
+        return (
+            abs(self.get_cpu_usage() - self.cpu_threshold)
+            > settings.AUTOSCALER_MARGIN_THRESHOLD
+        )
+
+    def mem_needs_scaling(self) -> bool:
+        return (
+            abs(self.get_mem_usage() - self.mem_threshold)
+            > settings.AUTOSCALER_MARGIN_THRESHOLD
+        )

--- a/asgard/workers/models/scalable_app.py
+++ b/asgard/workers/models/scalable_app.py
@@ -1,4 +1,5 @@
 from asgard.conf import settings
+from typing import Optional
 from asgard.workers.models.app_stats import AppStats
 
 
@@ -6,11 +7,11 @@ class ScalableApp:
     def __init__(
         self,
         appid: str,
-        cpu_allocated: float = None,
-        mem_allocated: float = None,
-        cpu_threshold: float = None,
-        mem_threshold: float = None,
-        app_stats: AppStats = None,
+        cpu_allocated: Optional[float] = None,
+        mem_allocated: Optional[float] = None,
+        cpu_threshold: Optional[float] = None,
+        mem_threshold: Optional[float] = None,
+        app_stats: Optional[AppStats] = None,
         min_cpu_scale_limit: float = settings.MIN_CPU_SCALE_LIMIT,
         max_cpu_scale_limit: float = settings.MAX_CPU_SCALE_LIMIT,
         min_mem_scale_limit: float = settings.MIN_MEM_SCALE_LIMIT,
@@ -36,10 +37,10 @@ class ScalableApp:
     def is_set_to_scale(self) -> bool:
         return self.is_set_to_scale_cpu() or self.is_set_to_scale_mem()
 
-    def get_cpu_usage(self) -> float:
+    def get_cpu_usage(self) -> Optional[float]:
         return self.app_stats.cpu_usage
 
-    def get_mem_usage(self) -> float:
+    def get_mem_usage(self) -> Optional[float]:
         return self.app_stats.mem_usage
 
     def cpu_needs_scaling(self) -> bool:

--- a/asgard/workers/models/scalable_app.py
+++ b/asgard/workers/models/scalable_app.py
@@ -1,5 +1,6 @@
-from asgard.conf import settings
 from typing import Optional
+
+from asgard.conf import settings
 from asgard.workers.models.app_stats import AppStats
 
 

--- a/itests/asgard/backends/test_chronos_scheduled_jobs_backend.py
+++ b/itests/asgard/backends/test_chronos_scheduled_jobs_backend.py
@@ -259,6 +259,7 @@ class ChronosScheduledJobsBackendTest(TestCase):
         returned_job = await self.backend.create_job(
             self.asgard_job, user, account
         )
+        await asyncio.sleep(0.3)
         stored_job = await self.backend.get_job_by_id(
             returned_job.id, user, account
         )

--- a/tests/asgard/workers/autoscaler/test_fetch_apps_data.py
+++ b/tests/asgard/workers/autoscaler/test_fetch_apps_data.py
@@ -313,8 +313,8 @@ class TestFetchAppsData(TestCase):
                 "stats": {
                     "type": "ASGARD",
                     "errors": {},
-                    "cpu_pct": "0.93",
-                    "ram_pct": "8.91",
+                    "cpu_pct": "93",
+                    "ram_pct": "80.9",
                     "cpu_thr_pct": "0.06",
                 }
             }
@@ -326,7 +326,7 @@ class TestFetchAppsData(TestCase):
                 payload=payload,
             )
 
-            fixture = AppStats(cpu_usage=0.93, mem_usage=8.91)
+            fixture = AppStats(cpu_usage=0.93, mem_usage=0.809)
 
             app_stats = await scaler.get_app_stats(app)
 


### PR DESCRIPTION
Conforme verificado ao investigar a issue #195, o componente de decisão estava enviando decisões ao Asgard mesmo quando a decisão não alterava a configuração da APP.

O problema estava ocorrendo pois, em casos onde a aplicação já estava utilizando os recursos ao mínimo/máximo, o decisor decidia escalar a aplicação mas sua decisão era limitada pelos valores mínimos/máximos, que já estavam uso.